### PR TITLE
Missing comma after openWalletRPC()

### DIFF
--- a/src/src/renderer/components/Wallet/WalletSetup.vue
+++ b/src/src/renderer/components/Wallet/WalletSetup.vue
@@ -118,7 +118,7 @@ export default {
         message: "start_wallet",
         path: executablePath
       }))
-    }
+    },
 
     createWallet(filename, password) {
       var self = this;


### PR DESCRIPTION
```
openWalletRPC() {
      var electroDir = require('os').homedir() + '\\Desktop\\electrovault_wallet';
      var executablePath = electroDir + '\\electroneum-wallet-rpc.exe';
      console.log(ipcRenderer.sendSync('synchronous-message', {
        message: "start_wallet",
        path: executablePath
      }))
    }
```

Added a comma
```
openWalletRPC() {
      var electroDir = require('os').homedir() + '\\Desktop\\electrovault_wallet';
      var executablePath = electroDir + '\\electroneum-wallet-rpc.exe';
      console.log(ipcRenderer.sendSync('synchronous-message', {
        message: "start_wallet",
        path: executablePath
      }))
    },
```