### PR TITLE
Fixed semicolon in createWallet()

### DIFF
--- a/src/src/renderer/components/Wallet/WalletSetup.vue
+++ b/src/src/renderer/components/Wallet/WalletSetup.vue
@@ -130,8 +130,8 @@ export default {
           "filename": filename,
           "password": password,
           "language": "English"
-        };
-      }
+        }
+      };
       var res = self.jsonRpcRequest(body).then(function(result) {
         console.log(result);
         self.walletComplete();


### PR DESCRIPTION
```
createWallet(filename, password) {
      var self = this;
      var body = {
        "jsonrpc": "2.0",
        "id": "0",
        "method": "create_wallet",
        "params": {
          "filename": filename,
          "password": password,
          "language": "English"
        };
      }
```
Moved semocolon

```
createWallet(filename, password) {
      var self = this;
      var body = {
        "jsonrpc": "2.0",
        "id": "0",
        "method": "create_wallet",
        "params": {
          "filename": filename,
          "password": password,
          "language": "English"
        }
      };
```